### PR TITLE
Add navbar and group videos by year

### DIFF
--- a/index.css
+++ b/index.css
@@ -5,8 +5,13 @@ body {
   text-align: center;
 }
 
+nav {
+  background: #222;
+  padding: 10px 0;
+}
+
 h1 {
-  margin-top: 20px;
+  margin: 0;
 }
 
 .grid {
@@ -33,4 +38,8 @@ h1 {
 .thumb span {
   display: block;
   margin-top: 8px;
+}
+
+.year-heading {
+  margin-top: 30px;
 }

--- a/index.html
+++ b/index.html
@@ -6,8 +6,10 @@
   <link rel="stylesheet" href="index.css">
 </head>
 <body>
-  <h1>🎬 Wybierz film</h1>
-  <div class="grid" id="gallery"></div>
+  <nav>
+    <h1>🎬 Wybierz film</h1>
+  </nav>
+  <div id="gallery"></div>
 
   <script src="index.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -6,18 +6,41 @@ const videos = [
 
 const gallery = document.getElementById("gallery");
 
+const videosByYear = {};
 videos.forEach(video => {
-  const base = video.file.replace(".mp4", "");
-  const thumb = `${base}_img.jpg`;
-
-  const a = document.createElement("a");
-  a.href = `player.html?video=${encodeURIComponent(video.file)}`;
-  a.className = "thumb";
-
-  a.innerHTML = `
-    <img src="${thumb}" alt="miniatura">
-    <span>${video.title}</span>
-  `;
-
-  gallery.appendChild(a);
+  const yearPrefix = video.file.slice(0, 2);
+  const year = `20${yearPrefix}`;
+  if (!videosByYear[year]) {
+    videosByYear[year] = [];
+  }
+  videosByYear[year].push(video);
 });
+
+Object.keys(videosByYear)
+  .sort((a, b) => b.localeCompare(a))
+  .forEach(year => {
+    const heading = document.createElement("h2");
+    heading.textContent = year;
+    heading.className = "year-heading";
+    gallery.appendChild(heading);
+
+    const grid = document.createElement("div");
+    grid.className = "grid";
+    gallery.appendChild(grid);
+
+    videosByYear[year].forEach(video => {
+      const base = video.file.replace(".mp4", "");
+      const thumb = `${base}_img.jpg`;
+
+      const a = document.createElement("a");
+      a.href = `player.html?video=${encodeURIComponent(video.file)}`;
+      a.className = "thumb";
+
+      a.innerHTML = `
+        <img src="${thumb}" alt="miniatura">
+        <span>${video.title}</span>
+      `;
+
+      grid.appendChild(a);
+    });
+  });


### PR DESCRIPTION
## Summary
- add a navigation bar and move the heading inside it
- group videos on the index page by the year encoded in filenames
- basic styling for the navbar and year headings

## Testing
- `node -e "require('./index.js')"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686c26fbba0c8328979db233e57e620a